### PR TITLE
feat(common.socket): added allowed_sources configuration option to socket plugin

### DIFF
--- a/plugins/common/socket/datagram.go
+++ b/plugins/common/socket/datagram.go
@@ -36,16 +36,9 @@ type packetListener struct {
 	parsePool *pond.WorkerPool
 }
 
-func newPacketListener(encoding string, maxDecompressionSize config.Size, maxWorkers int, allowedSources []string) *packetListener {
-	var parsedIPs []net.IP
-	for _, ipStr := range allowedSources {
-		if ip := net.ParseIP(ipStr); ip != nil {
-			parsedIPs = append(parsedIPs, ip)
-		}
-	}
-
+func newPacketListener(encoding string, maxDecompressionSize config.Size, maxWorkers int, allowedSources []net.IP) *packetListener {
 	return &packetListener{
-		AllowedSources:       parsedIPs,
+		AllowedSources:       allowedSources,
 		Encoding:             encoding,
 		MaxDecompressionSize: int64(maxDecompressionSize),
 		parsePool:            pond.New(maxWorkers, 0, pond.MinWorkers(maxWorkers/2+1)),

--- a/plugins/common/socket/datagram.go
+++ b/plugins/common/socket/datagram.go
@@ -66,13 +66,19 @@ func (l *packetListener) listenData(onData CallbackData, onError CallbackError) 
 
 			if len(l.AllowedSources) > 0 {
 				allowed := false
-				srcIP := ""
-				if udpAddr, ok := src.(*net.UDPAddr); ok {
-					srcIP = udpAddr.IP.String()
+				sourceIP := ""
+
+				switch addr := src.(type) {
+				case *net.UDPAddr:
+					sourceIP = addr.IP.String()
+				case *net.TCPAddr:
+					sourceIP = addr.IP.String()
+				case *net.IPAddr:
+					sourceIP = addr.IP.String()
 				}
 
 				for _, allowedSrc := range l.AllowedSources {
-					if srcIP == allowedSrc {
+					if sourceIP == allowedSrc {
 						allowed = true
 						break
 					}

--- a/plugins/common/socket/socket.conf
+++ b/plugins/common/socket/socket.conf
@@ -35,3 +35,8 @@
 
   ## Maximum size of decoded packet (in bytes when no unit specified)
   # max_decompression_size = "500MB"
+
+  ## List of allowed source IP addresses for incoming packets/connections.
+  ## Only packets/connections from these IPs will be accepted.
+  ## If not specified or empty, all sources are allowed.
+  # allowed_sources = ["172.18.237.26", "10.65.3.1"]

--- a/plugins/common/socket/socket.conf
+++ b/plugins/common/socket/socket.conf
@@ -37,6 +37,5 @@
   # max_decompression_size = "500MB"
 
   ## List of allowed source IP addresses for incoming packets/messages.
-  ## Only packets/messages from these IPs will be accepted.
   ## If not specified or empty, all sources are allowed.
-  # allowed_sources = [""192.168.1.100", "10.0.0.50""]
+  # allowed_sources = []

--- a/plugins/common/socket/socket.conf
+++ b/plugins/common/socket/socket.conf
@@ -36,7 +36,7 @@
   ## Maximum size of decoded packet (in bytes when no unit specified)
   # max_decompression_size = "500MB"
 
-  ## List of allowed source IP addresses for incoming packets/connections.
-  ## Only packets/connections from these IPs will be accepted.
+  ## List of allowed source IP addresses for incoming packets/messages.
+  ## Only packets/messages from these IPs will be accepted.
   ## If not specified or empty, all sources are allowed.
-  # allowed_sources = ["172.18.237.26", "10.65.3.1"]
+  # allowed_sources = [""192.168.1.100", "10.0.0.50""]

--- a/plugins/common/socket/socket.go
+++ b/plugins/common/socket/socket.go
@@ -36,6 +36,7 @@ type Config struct {
 	ContentEncoding      string           `toml:"content_encoding"`
 	MaxDecompressionSize config.Size      `toml:"max_decompression_size"`
 	MaxParallelParsers   int              `toml:"max_parallel_parsers"`
+	AllowedSources       []string         `toml:"allowed_sources"`
 	common_tls.ServerConfig
 }
 
@@ -123,19 +124,19 @@ func (s *Socket) Setup() error {
 		}
 		s.listener = l
 	case "udp", "udp4", "udp6":
-		l := newPacketListener(s.ContentEncoding, s.MaxDecompressionSize, s.MaxParallelParsers)
+		l := newPacketListener(s.ContentEncoding, s.MaxDecompressionSize, s.MaxParallelParsers, s.AllowedSources)
 		if err := l.setupUDP(s.url, s.interfaceName, int(s.ReadBufferSize)); err != nil {
 			return err
 		}
 		s.listener = l
 	case "ip", "ip4", "ip6":
-		l := newPacketListener(s.ContentEncoding, s.MaxDecompressionSize, s.MaxParallelParsers)
+		l := newPacketListener(s.ContentEncoding, s.MaxDecompressionSize, s.MaxParallelParsers, s.AllowedSources)
 		if err := l.setupIP(s.url); err != nil {
 			return err
 		}
 		s.listener = l
 	case "unixgram":
-		l := newPacketListener(s.ContentEncoding, s.MaxDecompressionSize, s.MaxParallelParsers)
+		l := newPacketListener(s.ContentEncoding, s.MaxDecompressionSize, s.MaxParallelParsers, s.AllowedSources)
 		if err := l.setupUnixgram(s.url, s.SocketMode, int(s.ReadBufferSize)); err != nil {
 			return err
 		}

--- a/plugins/common/socket/socket.go
+++ b/plugins/common/socket/socket.go
@@ -36,7 +36,7 @@ type Config struct {
 	ContentEncoding      string           `toml:"content_encoding"`
 	MaxDecompressionSize config.Size      `toml:"max_decompression_size"`
 	MaxParallelParsers   int              `toml:"max_parallel_parsers"`
-	AllowedSources       []string         `toml:"allowed_sources"`
+	AllowedSources       []net.IP         `toml:"allowed_sources"`
 	common_tls.ServerConfig
 }
 

--- a/plugins/common/socket/stream.go
+++ b/plugins/common/socket/stream.go
@@ -269,7 +269,9 @@ func (l *streamListener) listenData(onData CallbackData, onError CallbackError) 
 				}
 				continue
 			} else if !allowed {
-				_ = conn.Close()
+				if err = conn.Close(); err != nil {
+					onError(fmt.Errorf("closing connection from %q failed: %w", conn.RemoteAddr(), err))
+				}
 				continue
 			}
 
@@ -327,10 +329,14 @@ func (l *streamListener) listenConnection(onConnection CallbackConnection, onErr
 				if onError != nil {
 					onError(err)
 				}
-				_ = conn.Close()
+				if err = conn.Close(); err != nil {
+					onError(fmt.Errorf("closing connection from %q failed: %w", conn.RemoteAddr(), err))
+				}
 				continue
 			} else if !allowed {
-				_ = conn.Close()
+				if err = conn.Close(); err != nil {
+					onError(fmt.Errorf("closing connection from %q failed: %w", conn.RemoteAddr(), err))
+				}
 				l.Log.Debugf("Received message from blocked IP: %s", conn.RemoteAddr())
 				continue
 			}

--- a/plugins/common/socket/stream.go
+++ b/plugins/common/socket/stream.go
@@ -331,6 +331,7 @@ func (l *streamListener) listenConnection(onConnection CallbackConnection, onErr
 				continue
 			} else if !allowed {
 				_ = conn.Close()
+				l.Log.Debugf("Received message from blocked IP: %s", conn.RemoteAddr())
 				continue
 			}
 

--- a/plugins/common/socket/stream.go
+++ b/plugins/common/socket/stream.go
@@ -264,7 +264,9 @@ func (l *streamListener) listenData(onData CallbackData, onError CallbackError) 
 				if onError != nil {
 					onError(err)
 				}
-				_ = conn.Close()
+				if err := conn.Close(); err != nil {
+					onError(fmt.Errorf("closing connection from %q failed: %w", conn.RemoteAddr(), err))
+				}
 				continue
 			} else if !allowed {
 				_ = conn.Close()

--- a/plugins/inputs/socket_listener/README.md
+++ b/plugins/inputs/socket_listener/README.md
@@ -87,9 +87,8 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   # max_decompression_size = "500MB"
 
   ## List of allowed source IP addresses for incoming packets/messages.
-  ## Only packets/messages from these IPs will be accepted.
   ## If not specified or empty, all sources are allowed.
-  # allowed_sources = [""192.168.1.100", "10.0.0.50""]
+  # allowed_sources = []
 
   ## Message splitting strategy and corresponding settings for stream sockets
   ## (tcp, tcp4, tcp6, unix or unixpacket). The setting is ignored for packet

--- a/plugins/inputs/socket_listener/README.md
+++ b/plugins/inputs/socket_listener/README.md
@@ -86,6 +86,11 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## Maximum size of decoded packet (in bytes when no unit specified)
   # max_decompression_size = "500MB"
 
+  ## List of allowed source IP addresses for incoming packets/messages.
+  ## Only packets/messages from these IPs will be accepted.
+  ## If not specified or empty, all sources are allowed.
+  # allowed_sources = [""192.168.1.100", "10.0.0.50""]
+
   ## Message splitting strategy and corresponding settings for stream sockets
   ## (tcp, tcp4, tcp6, unix or unixpacket). The setting is ignored for packet
   ## listeners such as udp.

--- a/plugins/inputs/socket_listener/sample.conf
+++ b/plugins/inputs/socket_listener/sample.conf
@@ -51,6 +51,11 @@
   ## Maximum size of decoded packet (in bytes when no unit specified)
   # max_decompression_size = "500MB"
 
+  ## List of allowed source IP addresses for incoming packets/messages.
+  ## Only packets/messages from these IPs will be accepted.
+  ## If not specified or empty, all sources are allowed.
+  # allowed_sources = [""192.168.1.100", "10.0.0.50""]
+
   ## Message splitting strategy and corresponding settings for stream sockets
   ## (tcp, tcp4, tcp6, unix or unixpacket). The setting is ignored for packet
   ## listeners such as udp.

--- a/plugins/inputs/socket_listener/sample.conf
+++ b/plugins/inputs/socket_listener/sample.conf
@@ -52,9 +52,8 @@
   # max_decompression_size = "500MB"
 
   ## List of allowed source IP addresses for incoming packets/messages.
-  ## Only packets/messages from these IPs will be accepted.
   ## If not specified or empty, all sources are allowed.
-  # allowed_sources = [""192.168.1.100", "10.0.0.50""]
+  # allowed_sources = []
 
   ## Message splitting strategy and corresponding settings for stream sockets
   ## (tcp, tcp4, tcp6, unix or unixpacket). The setting is ignored for packet

--- a/plugins/inputs/syslog/README.md
+++ b/plugins/inputs/syslog/README.md
@@ -92,9 +92,8 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   # max_decompression_size = "500MB"
 
   ## List of allowed source IP addresses for incoming packets/messages.
-  ## Only packets/messages from these IPs will be accepted.
   ## If not specified or empty, all sources are allowed.
-  # allowed_sources = [""192.168.1.100", "10.0.0.50""]
+  # allowed_sources = []
 
   ## Framing technique used for messages transport
   ## Available settings are:

--- a/plugins/inputs/syslog/README.md
+++ b/plugins/inputs/syslog/README.md
@@ -91,6 +91,11 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## Maximum size of decoded packet (in bytes when no unit specified)
   # max_decompression_size = "500MB"
 
+  ## List of allowed source IP addresses for incoming packets/messages.
+  ## Only packets/messages from these IPs will be accepted.
+  ## If not specified or empty, all sources are allowed.
+  # allowed_sources = [""192.168.1.100", "10.0.0.50""]
+
   ## Framing technique used for messages transport
   ## Available settings are:
   ##   octet-counting  -- see RFC5425#section-4.3.1 and RFC6587#section-3.4.1

--- a/plugins/inputs/syslog/sample.conf
+++ b/plugins/inputs/syslog/sample.conf
@@ -48,6 +48,11 @@
   ## Maximum size of decoded packet (in bytes when no unit specified)
   # max_decompression_size = "500MB"
 
+  ## List of allowed source IP addresses for incoming packets/messages.
+  ## Only packets/messages from these IPs will be accepted.
+  ## If not specified or empty, all sources are allowed.
+  # allowed_sources = [""192.168.1.100", "10.0.0.50""]
+
   ## Framing technique used for messages transport
   ## Available settings are:
   ##   octet-counting  -- see RFC5425#section-4.3.1 and RFC6587#section-3.4.1

--- a/plugins/inputs/syslog/sample.conf
+++ b/plugins/inputs/syslog/sample.conf
@@ -49,9 +49,8 @@
   # max_decompression_size = "500MB"
 
   ## List of allowed source IP addresses for incoming packets/messages.
-  ## Only packets/messages from these IPs will be accepted.
   ## If not specified or empty, all sources are allowed.
-  # allowed_sources = [""192.168.1.100", "10.0.0.50""]
+  # allowed_sources = []
 
   ## Framing technique used for messages transport
   ## Available settings are:


### PR DESCRIPTION
## Summary
The socket input plugin currently accepts data from all sources. This change adds an optional `allowed_sources` configuration option to the socket plugin that will allow to control which sources can send data to the input plugin. The key motivation is to make sure that only trusted sources contribute to collected data.

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
[Issue](https://github.com/influxdata/telegraf/issues/17995)

